### PR TITLE
🐛 QQ语音转换采样率错误，应为24000Hz

### DIFF
--- a/nonebot_plugin_dcqq_relay/utils.py
+++ b/nonebot_plugin_dcqq_relay/utils.py
@@ -172,7 +172,7 @@ def pydub_transform(origin_bytes: bytes, input_type: str, output_type: str) -> b
 def skil_to_ogg(skil_bytes: bytes) -> bytes:
     output_buffer = BytesIO()
 
-    pcm_bytes = pysilk.decode(skil_bytes, True, sample_rate=44100)
+    pcm_bytes = pysilk.decode(skil_bytes, True, sample_rate=24000)
     audio = AudioSegment.from_file(BytesIO(pcm_bytes), format="wav")
     audio.export(output_buffer, format="ogg")
 


### PR DESCRIPTION
如果按照目前的代码将QQ语音的采样率解释为44100Hz，则生成的`.ogg`文件会明显变慢，声调变低

使用[最新的Lagrange.Core实现](https://github.com/LagrangeDev/Lagrange.Core/releases/tag/nightly) + 最新版Nonebot2（OneBot v11协议）